### PR TITLE
AddBook - add timestamp to each book when added

### DIFF
--- a/navigation/components/AddBook.js
+++ b/navigation/components/AddBook.js
@@ -27,6 +27,7 @@ export default function AddBook() {
 	const [user_id, setUser_id] = useState(firebase.auth().currentUser.uid);
 	const [location, setLocation] = useState('Manchester');
 	const [borrower, setBorrower] = useState('');
+  	const [createdAt, setCreatedAt] = useState('');
 
 	const [searchTerms, setSearchTerms] = useState('');
 	const [searchResults, setSearchResults] = useState([
@@ -93,6 +94,7 @@ export default function AddBook() {
 			numberOfReviews: numberOfReviews,
 			location: location,
 			borrower: borrower,
+      		createdAt: firebase.firestore.FieldValue.serverTimestamp()
 		})
 			.then(() => {
 				console.log('data submitted');


### PR DESCRIPTION
Now books can be viewed in Firestore in descending order by timestamp so most recent is at the top of the list. Same might be achieved in our app's AvailableBooksList if there is a query added to the Firestore get request (which is in the Home screen js file.)

Firestore query could also be the way to specify 'get only books which do not belong to the lender', although this condition could also be applied in the frontend using the user_id from firebase.auth.