### PR TITLE
BookCard Lender's view of own book - remove message field for unlent book

### DIFF
--- a/navigation/components/BookCard.js
+++ b/navigation/components/BookCard.js
@@ -99,6 +99,7 @@ const BookCard = ({ route }) => {
 				</Text>
 				<br></br>
 				<br></br>
+				{!book.available && 
 				<View style={styles.messageContainer}>
 					<View >
 						{messageHistory.map((message) => {
@@ -137,6 +138,7 @@ const BookCard = ({ route }) => {
 						</TouchableOpacity>
 					</View>
 				</View>
+				}
 			</View>
 		</ScrollView>
 	);


### PR DESCRIPTION
Conditional rendering in BookCard so that messages/message field only renders for a requested book.
Lines 102 and 141.
(Books available for lending have no chat, because the chat only starts when the book is requested.)
